### PR TITLE
cabana: include <algorithm> in HTTP server to fix build

### DIFF
--- a/tools/cabana/http/server.cc
+++ b/tools/cabana/http/server.cc
@@ -1,5 +1,7 @@
 #include "tools/cabana/http/server.h"
 
+#include <algorithm>
+
 #include <QHostAddress>
 #include <QJsonArray>
 #include <QJsonDocument>


### PR DESCRIPTION
### Motivation
- The Cabana HTTP server used `std::max` when constructing DBC signal fields but did not include `<algorithm>`, causing a build/CI failure on some toolchains.

### Description
- Add `#include <algorithm>` to `tools/cabana/http/server.cc` so `std::max` is declared and the server compiles cleanly.

### Testing
- Ran `python3 -m py_compile tools/cabana/http/agent_client.py`, which succeeded. 
- Ran `uv run pre-commit run --files tools/cabana/http/server.cc` which failed due to an external network dependency (blocked download of a metadrive wheel).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0d48de0a483278bc47d497156b8aa)